### PR TITLE
21 add speak button on different widgets

### DIFF
--- a/TellTimeWidget/TellTimeWidget.swift
+++ b/TellTimeWidget/TellTimeWidget.swift
@@ -104,18 +104,22 @@ struct TellTimeWidgetView: View {
                 VStack {
                     digital
                 }
-            }.padding()
+            }
+            .padding()
+            .widgetURL(url())
         } else {
             HStack {
                 clock
                 VStack {
                     Text(time)
                     Spacer()
-                    Link(destination: URL(string: "speak")!) {
+                    Link(destination: url(speak: true)) {
                         speakButton
                     }
                 }
-            }.padding()
+            }
+            .padding()
+            .widgetURL(url())
         }
     }
 
@@ -127,12 +131,14 @@ struct TellTimeWidgetView: View {
                 Spacer()
                 Text(time)
                 Spacer()
-                Link(destination: URL(string: "speak")!) {
+                Link(destination: url(speak: true)) {
                     speakButton
                 }
             }
             Spacer()
-        }.padding()
+        }
+        .padding()
+        .widgetURL(url())
     }
 
     private var formattedTime: String {
@@ -190,6 +196,19 @@ struct TellTimeWidgetView: View {
             .cornerRadius(8)
             .background(Color.red.cornerRadius(8))
     }
+
+    private func url(speak: Bool = false) -> URL {
+        var urlComponents = URLComponents()
+        urlComponents.host = "renaud.jenny.telltime"
+        urlComponents.queryItems = [
+            URLQueryItem(name: "clockStyle", value: "\(design.clockStyle.id)"),
+            URLQueryItem(name: "speak", value: "\(speak)")
+        ]
+        guard let url = urlComponents.url else {
+            fatalError("Cannot build the URL from the Widget")
+        }
+        return url
+    }
 }
 
 @main
@@ -206,6 +225,19 @@ struct TellTimeWidget: Widget {
         }
         .configurationDisplayName("Tell Time UK")
         .description("Widget for help you telling you the time the British English way.")
+    }
+}
+
+extension Design {
+    var clockStyle: ClockStyle {
+        switch self {
+        case .unknown: return .classic
+        case .classic: return .classic
+        case .artNouveau: return .artNouveau
+        case .drawing: return .drawing
+        case .steampunk: return .steampunk
+        case .lewis: return .classic
+        }
     }
 }
 

--- a/TellTimeWidget/TellTimeWidget.swift
+++ b/TellTimeWidget/TellTimeWidget.swift
@@ -93,7 +93,6 @@ struct TellTimeWidgetView: View {
     private var smallView: some View {
         VStack {
             Text(time).padding()
-            Button("Speak", action: {})
         }
     }
 
@@ -104,8 +103,6 @@ struct TellTimeWidgetView: View {
                 clock
                 VStack {
                     digital
-                    Spacer()
-                    Button("Speak", action: {})
                 }
             }.padding()
         } else {
@@ -114,7 +111,9 @@ struct TellTimeWidgetView: View {
                 VStack {
                     Text(time)
                     Spacer()
-                    Button("Speak", action: {})
+                    Link(destination: URL(string: "speak")!) {
+                        speakButton
+                    }
                 }
             }.padding()
         }
@@ -128,7 +127,9 @@ struct TellTimeWidgetView: View {
                 Spacer()
                 Text(time)
                 Spacer()
-                Button("Speak", action: {})
+                Link(destination: URL(string: "speak")!) {
+                    speakButton
+                }
             }
             Spacer()
         }.padding()
@@ -180,6 +181,14 @@ struct TellTimeWidgetView: View {
                 Spacer()
             }
         }
+    }
+
+    private var speakButton: some View {
+        Image(systemName: "speaker.2")
+            .foregroundColor(.white)
+            .padding()
+            .cornerRadius(8)
+            .background(Color.red.cornerRadius(8))
     }
 }
 

--- a/TellTimeWidget/TellTimeWidget.swift
+++ b/TellTimeWidget/TellTimeWidget.swift
@@ -91,7 +91,10 @@ struct TellTimeWidgetView: View {
     }
 
     private var smallView: some View {
-        Text(time).padding()
+        VStack {
+            Text(time).padding()
+            Button("Speak", action: {})
+        }
     }
 
     @ViewBuilder
@@ -99,12 +102,20 @@ struct TellTimeWidgetView: View {
         if design == .lewis {
             HStack {
                 clock
-                digital
+                VStack {
+                    digital
+                    Spacer()
+                    Button("Speak", action: {})
+                }
             }.padding()
         } else {
             HStack {
                 clock
-                Text(time)
+                VStack {
+                    Text(time)
+                    Spacer()
+                    Button("Speak", action: {})
+                }
             }.padding()
         }
     }
@@ -113,7 +124,12 @@ struct TellTimeWidgetView: View {
         VStack {
             clock
             Spacer()
-            Text(time)
+            HStack {
+                Spacer()
+                Text(time)
+                Spacer()
+                Button("Speak", action: {})
+            }
             Spacer()
         }.padding()
     }

--- a/telltime/App/TellTimeUKApp.swift
+++ b/telltime/App/TellTimeUKApp.swift
@@ -22,7 +22,15 @@ struct TellTimeUKApp: SwiftUI.App {
 
     var body: some Scene {
         WindowGroup {
-            TellTimeView().environmentObject(store)
+            TellTimeView()
+                .environmentObject(store)
+                .onOpenURL(perform: { url in
+                    switch url.absoluteString {
+                    case "speak":
+                        store.send(.tts(.tellTime(Date())))
+                    default: break
+                    }
+                })
         }
     }
 }

--- a/telltime/App/TellTimeUKApp.swift
+++ b/telltime/App/TellTimeUKApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftTTSCombine
+import SwiftClockUI
 
 @main
 struct TellTimeUKApp: SwiftUI.App {
@@ -25,10 +26,19 @@ struct TellTimeUKApp: SwiftUI.App {
             TellTimeView()
                 .environmentObject(store)
                 .onOpenURL(perform: { url in
-                    switch url.absoluteString {
-                    case "speak":
+                    store.send(.changeDate(Date()))
+                    guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+                        return
+                    }
+                    guard
+                        let clockStyleValue = urlComponents.queryItems?.first(where: { $0.name == "clockStyle" })?.value,
+                        let clockStyle = ClockStyle.allCases.first(where: { String($0.id) == clockStyleValue })
+                    else {
+                        return
+                    }
+                    store.send(.configuration(.changeClockStyle(clockStyle)))
+                    if urlComponents.queryItems?.first(where: { $0.name == "speak" })?.value == "true" {
                         store.send(.tts(.tellTime(Date())))
-                    default: break
                     }
                 })
         }


### PR DESCRIPTION
Add Speak Button to middle sized and large sized widget. It's not possible yet to add a `Link` or `Button` to the small sized widget, so I skipped this one.

Fix #21 